### PR TITLE
Gears with custom twist profiles

### DIFF
--- a/cq_gears/__init__.py
+++ b/cq_gears/__init__.py
@@ -20,7 +20,7 @@ limitations under the License.
 __version__='0.62'
 
 import cadquery as cq
-from .spur_gear import SpurGear, HerringboneGear
+from .spur_gear import SpurGear, HerringboneGear, CustomTwistGear
 from .ring_gear import (RingGear, HerringboneRingGear, PlanetaryGearset,
                         HerringbonePlanetaryGearset)
 from .bevel_gear import BevelGear, BevelGearPair
@@ -32,6 +32,7 @@ from .crossed_helical_gear import (CrossedHelicalGear, CrossedGearPair,
 __all__ = [
     'SpurGear',
     'HerringboneGear',
+    'CustomTwistGear',
     'RingGear',
     'HerringboneRingGear',
     'PlanetaryGearset',

--- a/tests/stability/test_spur_gear.py
+++ b/tests/stability/test_spur_gear.py
@@ -1,7 +1,7 @@
 
 import numpy as np
 import cadquery as cq
-from cq_gears import SpurGear, HerringboneGear
+from cq_gears import SpurGear, HerringboneGear, CustomTwistGear
 
 from utils import (BuildFailure, SolidBuildFailure, VolumeCheckFailure,
                    BBoxZCheckFailure, BBoxXYCheckFailure)
@@ -93,3 +93,7 @@ class TestSpurGear(_TestGear):
 
 class TestHerringboneGear(TestSpurGear):
     gear_cls = HerringboneGear
+
+
+class TestCustomTwistGear(TestSpurGear):
+    gear_cls = CustomTwistGear


### PR DESCRIPTION
Hello,

First of all thanks for making this great library 😃 

I have implemented a new `CustomTwistGear` class, extending the `SpurGear` class.
It is quite similar to the `HerringboneGear` class, but instead of having a "V" shaped profile, it allows any twist profile as specified by a lambda function.

For example, it can be used to make a "sinusoidal curved gear profiles" [like in this paper](https://www.semanticscholar.org/paper/STRESS-ANALYSIS-OF-SINUSOIDAL-CURVED-GEAR-PROFILES-Irsel-Ayer/75a914a6a03b8fd5eed59af09c727052b3e4527a):

```python
gear = (
    cq.Workplane('XY')
    .gear(cq_gears.CustomTwistGear(
        module=2.0,
        teeth_number=10,
        width=10.0,
        twist_function=lambda t: np.sin(2*np.pi * t),
        twist_angle=10.0
    ))
)
```
![Result](https://user-images.githubusercontent.com/13591769/227722027-10fc2924-573b-4fca-b510-20e914e71e6b.png)

Rack gears etc. should be possible too though I haven't tried.